### PR TITLE
skip methods that look like swagger extension keys

### DIFF
--- a/lib/Mojolicious/Plugin/Swagger2.pm
+++ b/lib/Mojolicious/Plugin/Swagger2.pm
@@ -328,7 +328,7 @@ sub register {
   }
 
   for my $path (keys %$paths) {
-    for my $http_method (keys %{$paths->{$path}}) {
+    for my $http_method (grep { !/^x-/ } keys %{$paths->{$path}}) {
       my $info       = $paths->{$path}{$http_method};
       my $route_path = $path;
       my %parameters = map { ($_->{name}, $_) } @{$info->{parameters} || []};

--- a/t/data/petstore.json
+++ b/t/data/petstore.json
@@ -21,6 +21,9 @@
   },
   "paths": {
     "/pets": {
+      "x-something-something": {
+        "x-nothing-here" : "No, really!"
+      },
       "get": {
         "x-mojo-controller": "t::Api",
         "tags": [ "pets" ],

--- a/t/data/petstore.yaml
+++ b/t/data/petstore.yaml
@@ -15,6 +15,8 @@ produces:
   - application/json
 paths:
   /pets:
+    x-something-something:
+      x-nothing-here: No, really!
     get:
       x-mojo-controller: "t::Api"
       summary: List all pets


### PR DESCRIPTION
swagger extensions, "x-..." keys, can be anywhere in the config and
if they're in the method section of the path then trying to create
a mojo route from these isn't going to work. add a couple of these
keys to the petstore examples for testing