### PR TITLE
Add Path Objects to Mojolicious in lenghtwise order from shortest to …

### DIFF
--- a/lib/Mojolicious/Plugin/Swagger2.pm
+++ b/lib/Mojolicious/Plugin/Swagger2.pm
@@ -373,7 +373,7 @@ sub register {
     $r->to(swagger => $swagger);
   }
 
-  for my $path (keys %$paths) {
+  for my $path (sort {length $a <=> length $b} keys %$paths) {
     $paths->{$path}{'x-mojo-around-action'} ||= $swagger->api_spec->get('/x-mojo-around-action');
     $paths->{$path}{'x-mojo-controller'}    ||= $swagger->api_spec->get('/x-mojo-controller');
 

--- a/t/Api.pm
+++ b/t/Api.pm
@@ -30,6 +30,13 @@ sub list_pets {
   $c->$cb($RES, $CODE);
 }
 
+sub status {
+  my ($c, $args, $cb) = @_;
+  my $resp = {};
+  $resp->{status} = $RES;
+  $c->$cb($resp, $CODE);
+}
+
 sub query_as_array {
   my ($c, $args, $cb) = @_;
   $c->$cb($args, $CODE);

--- a/t/order-pathobjects-lengthwise.t
+++ b/t/order-pathobjects-lengthwise.t
@@ -1,0 +1,63 @@
+use Mojo::Base -strict;
+use Mojolicious;
+use Test::Mojo;
+use Test::More;
+use File::Spec::Functions;
+use t::Api;
+
+#Run this test 11 times, to make sure that we can reproduce the bug which happens 50% of time.
+#If /pets/{petnumber} is added to Mojolicious before /pets/status, /pets/{petnumber} overlaps
+#/pets/status and all requests which should go to /pets/status are instead put to /pets/{petnumber}.
+#Making sure we introduce new routes shortest route first
+
+subtest "Lenghtwise Route introduction" => \&testRandomRouteIntroduction;
+sub testRandomRouteIntroduction {
+  foreach (0..10) {
+    my $app = Mojolicious->new;
+    $app->plugin(Swagger2 => {url => "data://main/lenghtwise.json"});
+    my $t = Test::Mojo->new($app);
+
+    $t::Api::CODE = 200;
+    $t::Api::RES = {stat_tus => 'ok'};
+    $t->get_ok('/api/pets/status')->status_is(200)->json_is('/status/stat_tus', 'ok');
+
+    $t->get_ok('/api/pets/5')->status_is(200)->json_is('/stat_tus', 'ok');
+  }
+}
+
+done_testing;
+
+__DATA__
+@@ lenghtwise.json
+{
+  "swagger": "2.0",
+  "basePath": "/api",
+  "paths": {
+    "/pets/status": {
+      "get": {
+        "x-mojo-controller": "t::Api",
+        "operationId": "status",
+        "responses": {
+          "200": {"description": "anything"}
+        }
+      }
+    },
+    "/pets/{petnumber}": {
+      "get": {
+        "x-mojo-controller": "t::Api",
+        "operationId": "getPet",
+        "parameters": [
+          {
+            "name": "petnumber",
+            "in": "path",
+            "required": "true",
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {"description": "anything"}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
…longest path.

Currently the Swagger2 Path Objects are added to the Mojolicious routing table
in a random order.
This patch fixes the ordering to be from shortest path to longest:

eg:
/pets/status is added before /pets/{petnumber}

The order of adding routes to the Mojolicious roting table is important, so it
is good to be consistent about it in the Swagger2-plugin as well.