### PR TITLE
do not add undefined entries in $input when not required

### DIFF
--- a/lib/Mojolicious/Plugin/Swagger2.pm
+++ b/lib/Mojolicious/Plugin/Swagger2.pm
@@ -149,9 +149,11 @@ sub dispatch_to_swagger {
   for my $p (@{$op_info->{spec}{parameters} || []}) {
     my $name  = $p->{name};
     my $value = $data->{params}{$name} // $p->{default};
-    my @e     = $self->_validate_input_value($p, $name => $value);
-    $input->{$name} = $value unless @e;
-    push @errors, @e;
+    if (defined $value or Swagger2::_is_true($p->{required})) {
+        my @e     = $self->_validate_input_value($p, $name => $value);
+        $input->{$name} = $value unless @e;
+        push @errors, @e;
+    }
   }
 
   return $c->$reply({errors => \@errors}, 400) if @errors;
@@ -483,9 +485,11 @@ sub _validate_input {
       }
     }
 
-    my @e = $self->_validate_input_value($p, $name => $value);
-    $input{$name} = $value unless @e;
-    push @errors, @e;
+    if (defined $value or Swagger2::_is_true($p->{required})) {
+        my @e = $self->_validate_input_value($p, $name => $value);
+        $input{$name} = $value unless @e;
+        push @errors, @e;
+    }
   }
 
   return {errors => \@errors}, \%input;

--- a/t/collection-format.t
+++ b/t/collection-format.t
@@ -14,9 +14,7 @@ $t->get_ok('/collection/format/string?foo=1,x,3')->status_is(200)->content_is('{
 $t->get_ok('/collection/format/string?foo=x')->status_is(200)->content_is('{"foo":["x"]}');
 $t->get_ok('/collection/format/array?foo=1|2,3|4')->status_is(200)->content_is('{"foo":[["1","2"],["3","4"]]}');
 $t->get_ok('/collection/format/string?foo=')->status_is(200)->content_is('{"foo":[]}');
-
-local $TODO = 'Should foo even be part of $input in this case?';
-$t->get_ok('/collection/format/string')->status_is(200)->content_is('{"foo":null}');
+$t->get_ok('/collection/format/string')->status_is(200)->content_is('{}');
 
 done_testing;
 


### PR DESCRIPTION
When a parameter is not required, it should not be part of the $input ($args) passed to the controller if the parameter was not specified (e.g., via a query string or POST parameter). This avoids having to strip out undefined key/value pairs in the controller: $args has exactly what was passed in, along with any parameters with defaults, etc.