### PR TITLE
Remove obsolete /o regex modifier in Swagger2::SchemaValidator

### DIFF
--- a/lib/Swagger2/SchemaValidator.pm
+++ b/lib/Swagger2/SchemaValidator.pm
@@ -68,7 +68,7 @@ sub _coerce_by_collection_format {
 }
 
 sub _is_byte_string { $_[0] =~ /^[A-Za-z0-9\+\/\=]+$/; }
-sub _is_date        { $_[0] =~ qr/^(\d+)-(\d+)-(\d+)$/io; }
+sub _is_date        { $_[0] =~ qr/^(\d+)-(\d+)-(\d+)$/i; }
 
 sub _is_number {
   return unless $_[0] =~ /^-?\d+(\.\d+)?$/;


### PR DESCRIPTION
So I stumbled upon the `/o` regex modifier in your code and wanted to know what it does. After reading some documentation I am pretty sure this is obsolete and you just copied it with the datetime regex when originally introduced the `/o` in 901c1c1. This PR is to justify the amount of time I spent looking into this.

I checked that `/o` is nowhere else used in this repo. it is not.

This PR is by far my tiniest contribution ever;-)

Commit message:

Anything from obsolete to buggy according to

- http://perldoc.perl.org/perlre.html#Modifiers

- http://perldoc.perl.org/perlop.html#Regexp-Quote-Like-Operators

"The bottom line is that using /o is almost never a good idea." perlop