### PR TITLE
CSV Brackets

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for perl distribution Swagger2
 
+0.76 Not Released
+ - Add brackets support to csv collectionFormat
+
 0.75 2016-02-22T09:02:43+0000
  - Fix indentation of JSONSchemaSupport guide
 

--- a/lib/Swagger2/SchemaValidator.pm
+++ b/lib/Swagger2/SchemaValidator.pm
@@ -4,7 +4,7 @@ use Scalar::Util ();
 
 use constant IV_SIZE => eval 'require Config;$Config::Config{ivsize}';
 
-our %COLLECTION_RE = (pipes => qr{\|}, csv => qr{,}, ssv => qr{\s}, tsv => qr{\t});
+our %COLLECTION_RE = (pipes => qr{\|}, csv => qr{[,](?![^(]*\))}, ssv => qr{\s}, tsv => qr{\t});
 
 sub validate_input {
   my $self = shift;

--- a/t/collection-format.t
+++ b/t/collection-format.t
@@ -11,6 +11,7 @@ my $t = Test::Mojo->new;
 $t->get_ok('/collection/format/integer?foo=1|2|3')->status_is(200)->content_is('{"foo":[1,2,3]}');
 $t->get_ok('/collection/format/number?foo=1.42 2 3.14')->status_is(200)->content_is('{"foo":[1.42,2,3.14]}');
 $t->get_ok('/collection/format/string?foo=1,x,3')->status_is(200)->content_is('{"foo":["1","x","3"]}');
+$t->get_ok('/collection/format/string?foo=1,(x,3)')->status_is(200)->content_is('{"foo":["1","(x,3)"]}');
 $t->get_ok('/collection/format/string?foo=x')->status_is(200)->content_is('{"foo":["x"]}');
 $t->get_ok('/collection/format/array?foo=1|2,3|4')->status_is(200)->content_is('{"foo":[["1","2"],["3","4"]]}');
 $t->get_ok('/collection/format/string?foo=')->status_is(200)->content_is('{"foo":[]}');


### PR DESCRIPTION
This pull request adds basic support for bracketed sets within csv collections.

I'm pretty sure it conform to the relevant RFC's for URL's.

This change allows for the following to be interpreted 'correctly'.

```
?collection=a,b,(c,d)
```

before patch: [ "a", "b", "(c", "d)" ]
after patch: [ "a", "b", "(c,d)" ]

Any comments welcome before I go ahead and merge this