### PR TITLE
Add EXPERIMENTAL support for OPTIONS which returns swagger spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for perl distribution Swagger2
 
 0.78 Not Released
  - Add EXPERIMENTAL .html and .pod handling for "spec_path" rendering
+ - Add EXPERIMENTAL support for OPTIONS which returns swagger spec
 
 0.77 2016-04-12T08:32:56+0200
  - Add Swagger2->find_operations() method

--- a/t/around-action.t
+++ b/t/around-action.t
@@ -5,18 +5,23 @@ use Test::More;
 use File::Spec::Functions;
 use t::Api;
 
-for my $file (qw( around-action inherit-path inherit-global )) {
+for my $file (qw(around-action inherit-path inherit-global)) {
   my $app = Mojolicious->new;
   $app->plugin(Swagger2 => {url => "data://main/$file.json"});
   my $t = Test::Mojo->new($app);
 
   $t::Api::CODE = 401;
   $t::Api::RES = [{id => 123, name => "kit-cat"}];
-  $t->get_ok('/api/pets')->status_is(401)->json_is('/operationId', 'listPets')->json_is('/x-mojo-controller', 't::Api')
-    ->json_is('/x-mojo-around-action', 't::Api::authenticate')->json_is('/responses/200/description', 'anything');
+  $t->get_ok('/api/pets')->status_is(401)->json_is('/operationId', 'listPets')
+    ->json_is('/x-mojo-controller',         't::Api')
+    ->json_is('/x-mojo-around-action',      't::Api::authenticate')
+    ->json_is('/responses/200/description', 'anything');
+
+  $t->options_ok('/api/pets')->status_is(401) if $file ne 'around-action';
 
   $t::Api::CODE = 200;
   $t->get_ok('/api/pets')->status_is(200);
+  $t->options_ok('/api/pets')->status_is(200);
 }
 
 done_testing;

--- a/t/plugin.t
+++ b/t/plugin.t
@@ -38,6 +38,9 @@ $t->post_ok('/api/pets/42')->status_is(200)->json_is('/id', 42)->json_is('/name'
 $t->post_ok('/api/pets/foo')->status_is(400)->json_is('/errors/0/path', '/petId')
   ->json_is('/errors/0/message', 'Expected integer - got string.')->json_is('/errors/1', undef);
 
+$t->options_ok('/api/pets/foo')->status_is(200)->header_is(Allow => 'POST')
+  ->json_is('/post/responses/default/description', 'unexpected error');
+
 $t->get_ok('/api')->status_is(200)->json_is('/info/title', 'Swagger Petstore');
 my $api_spec = $t->tx->res->json;
 like $api_spec->{host}, qr{:\d+$}, 'petstore.swagger.wordnik.com is replaced';


### PR DESCRIPTION
I've added support for OPTIONS, but I'm not entirely sure if it should be enabled by default: The issue I see is that someone who has specified "x-mojo-around-action" on the lowest level will not protect the OPTIONS request. I'm not sure if this matters, since you can only extract the spec and no actual data.

I would very much like to have this enabled by default.