### PR TITLE
Swagger2::Client should set content type on faked error responses

### DIFF
--- a/lib/Swagger2/Client.pm
+++ b/lib/Swagger2/Client.pm
@@ -102,6 +102,7 @@ HERE
 
 sub _invalid_input_res {
   my $res = Mojo::Message::Response->new;
+  $res->headers->content_type('application/json');
   $res->body(Mojo::JSON::encode_json({errors => $_[0]}));
   $res->code(400)->message($res->default_message);
   $res->error({message => 'Invalid input', code => 400});

--- a/t/client-return-on-error.t
+++ b/t/client-return-on-error.t
@@ -15,9 +15,12 @@ $client->base_url->host($ua->server->url->host);
 $client->base_url->port($ua->server->url->port);
 
 my $res = $client->return_on_error(1)->add_pet;
+
 is $res->code, 400, 'blocking 400';
 is $res->json->{errors}[0]{message}, 'Expected object - got null.', 'expected';
-
+is $res->headers->content_type, 'application/json',
+    'Content type set to application/json';
+    
 $t::Api::RES = {};
 $res = $client->show_pet_by_id({petId => 42});
 is $res->code, 500, 'blocking 500';


### PR DESCRIPTION

Just a tiny one.

Using return-on-error,

When writing applications which properly respect the content type response header, handling the faked schema-level error responses generated by ``Client.pm`` requires them to break their flow and intercept the request before it hits their decoding.

Something like:
- Intercept all 400s at a fairly low level
- Try to decode it as JSON
    - ***If it worked***: looking for signs that it is a Swagger / validation error
    - ***If it didn't***: blowing up with 'invalid/unknown content type'

This pull request simply adds the ``application/json`` content type header, so it can be handled at a more natural place, and pass through the normal decoding phases without causing havoc.
