### PR TITLE
client file uploads using formData file type parameters

### DIFF
--- a/lib/Swagger2/Client.pm
+++ b/lib/Swagger2/Client.pm
@@ -143,6 +143,11 @@ sub _validate_request {
           map { $_->{path} = $_->{path} eq "/" ? "/$name" : "/$name$_->{path}"; $_; }
           $self->_validator->validate($value, $p->{schema});
       }
+      elsif ($in eq 'formData' && $type eq 'file') {
+        # if this is a file parameter and there is data then do nothing
+        # as file data cannot be validated
+        warn "[Swagger2::Client] Validate $in $name (Skipping file)\n" if DEBUG;
+      }
       else {
         warn "[Swagger2::Client] Validate $in $name=$value\n" if DEBUG;
         push @e, $self->_validator->validate({$name => $value}, {properties => {$name => $p}});

--- a/lib/Swagger2/Client.pm
+++ b/lib/Swagger2/Client.pm
@@ -137,7 +137,7 @@ sub _validate_request {
           if $type eq 'boolean';
       }
 
-      if ($in eq 'body' or $in eq 'formData') {
+      if ($in eq 'body') {
         warn "[Swagger2::Client] Validate $in\n" if DEBUG;
         push @e,
           map { $_->{path} = $_->{path} eq "/" ? "/$name" : "/$name$_->{path}"; $_; }

--- a/lib/Swagger2/Client.pm
+++ b/lib/Swagger2/Client.pm
@@ -125,11 +125,11 @@ sub _validate_request {
   my (%data, $body, @e);
 
   for my $p (@{$op_spec->{parameters} || []}) {
-    my ($in, $name) = @$p{qw( in name )};
+    my ($in, $name, $type) = @$p{qw( in name type )};
     my $value = exists $args->{$name} ? $args->{$name} : $p->{default};
 
     if (defined $value or Swagger2::_is_true($p->{required})) {
-      my $type = $p->{type} || 'object';
+      $type ||= 'object';
 
       if (defined $value) {
         $value += 0 if $type =~ /^(?:integer|number)/ and $value =~ /^\d/;
@@ -155,9 +155,6 @@ sub _validate_request {
     elsif ($in eq 'query') {
       $query->param($name => $value);
     }
-    elsif ($in eq 'file') {
-      $body = $value;
-    }
     elsif ($in eq 'header') {
       $req->[1]{$name} = $value;
     }
@@ -165,7 +162,7 @@ sub _validate_request {
       $data{json} = $value;
     }
     elsif ($in eq 'formData') {
-      $data{form} = $value;
+      $data{form}{$name} = $value;
     }
   }
 

--- a/t/client.t
+++ b/t/client.t
@@ -41,6 +41,12 @@ like $@, qr{^Invalid input: /data: Expected object - got null}, 'add_pet invalid
 $res = $client->add_pet({data => {name => 'm4'}});
 is $res->json->{name}, 'm4', 'add_pet';
 
+$res = $client->add_image({data => {file => __FILE__}});
+is $res->code, 200, 'add_image ok';
+
+eval { $client->add_image({data => {bang => __FILE__}}) };
+like $@, qr{Missing property}, 'add_image invalid input';
+
 # async
 $t::Api::RES = [{id => 123, name => "kit-cat"}];
 $client->base_url->host($ua->server->nb_url->host);
@@ -61,6 +67,7 @@ Mojo::IOLoop->start;
 isa_ok($res, 'Mojo::Message::Response');
 is $res->json->{errors}[0]{message}, 'Expected integer - got string.', 'errors';
 is_deeply($err, 'Internal Server Error', 'list_pets async invalid output');
+
 
 # with path
 $t::Api::RES = {id => 123, name => "kit-cat"};

--- a/t/data/petstore.json
+++ b/t/data/petstore.json
@@ -107,6 +107,23 @@
           }
         }
       }
+    },
+    "/pets/avatar" : {
+      "post" : {
+        "x-mojo-controller": "t::Api",
+        "operationId" : "addImage",
+        "parameters" : [
+          { "name" : "data", "type" : "file", "in" : "formData", "required": true }
+        ],
+        "responses" : {
+          "200": {
+            "description": "pet response",
+            "schema": {
+              "type": "file"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {

--- a/t/parse-json.t
+++ b/t/parse-json.t
@@ -18,7 +18,7 @@ like $swagger->to_string, qr{"summary":"finds pets in the system"}, 'to_string';
 like $swagger->to_string('json'), qr{"summary":"finds pets in the system"}, 'to_string json';
 
 my $operations = $swagger->find_operations;
-is int @$operations, 3, 'all operations';
+is int @$operations, 4, 'all operations';
 
 $operations = $swagger->find_operations({tag => 'petx'});
 is int @$operations, 1, 'operations with tag pets';


### PR DESCRIPTION
A few bug fixes to get formData file parameters working in ``Client``


This pull request changes the handling as such:

- formData parameters cannot be complex types currently according to the Swagger specification (only simple types / primitives, or files), so change which ``_validate_request`` block handles them

- skip validating files completely as file content can't be validated, and SchemaValidator file validation is server-side specific (the file value needs to be passed to http://mojolicious.org/perldoc/Mojo/UserAgent/Transactor#tx untouched).

- formData parameters should be under ``$data{form}``, and not on top of it

- ``in: file`` is not a valid value for the ``in`` property



---

This pull request allows you to supply file values as:
```
$client->my_operation( foo => { content => $raw_content } );
$client->my_operation( foo => { file => './example.jpg' } );
```
As per the http://mojolicious.org/perldoc/Mojo/UserAgent/Transactor#tx form post syntax.
