### PR TITLE
A couple of minor fixes to support formData parameters.

### DIFF
--- a/lib/Swagger2/Client.pm
+++ b/lib/Swagger2/Client.pm
@@ -137,7 +137,7 @@ sub _validate_request {
           if $type eq 'boolean';
       }
 
-      if ($in eq 'body' or $in eq 'formData') {
+      if ($in eq 'body') {
         warn "[Swagger2::Client] Validate $in\n" if DEBUG;
         push @e,
           map { $_->{path} = $_->{path} eq "/" ? "/$name" : "/$name$_->{path}"; $_; }
@@ -165,7 +165,7 @@ sub _validate_request {
       $data{json} = $value;
     }
     elsif ($in eq 'formData') {
-      $data{form} = $value;
+      $data{form}{$name} = $value;
     }
   }
 


### PR DESCRIPTION
 1. Don't use the a schema to validate formData - The spec says body only
 2. When building the form, build it using name/value pairs and not just the value.